### PR TITLE
Refactor: Enhance readability with Japanese translations and node rename

### DIFF
--- a/files/backend_codes.py
+++ b/files/backend_codes.py
@@ -1,7 +1,7 @@
 # 【重要！！】コメントアウトやエラーメッセージはできる限り日本語で残すこと。
 
 from langchain_community.vectorstores import FAISS
-import difflib # Make sure this import is added at the top of the file
+import difflib # このインポートがファイルの先頭に追加されていることを確認してください
 import sqlite3
 import pandas as pd
 import logging
@@ -19,27 +19,27 @@ from datetime import datetime
 import japanize_matplotlib
 import seaborn as sns
 from langchain_google_genai import GoogleGenerativeAIEmbeddings, ChatGoogleGenerativeAI
-import json # Moved import json to the top
+import json # import jsonを先頭に移動しました
 
-# Configure basic logging
+# 基本的なロギングを設定
 logging.basicConfig(level=logging.INFO)
 
 google_api_key = os.getenv("GOOGLE_API_KEY")
-embeddings = GoogleGenerativeAIEmbeddings(model="models/embedding-001", google_api_key=google_api_key) # Or other suitable Gemini embedding model
+embeddings = GoogleGenerativeAIEmbeddings(model="models/embedding-001", google_api_key=google_api_key) # または他の適切なGemini埋め込みモデル
 SIMILARITY_THRESHOLD = 0.8
 
 # ベクトルストア
 vectorstore_tables = FAISS.load_local("faiss_tables", embeddings, allow_dangerous_deserialization=True)
 vectorstore_queries = FAISS.load_local("faiss_queries", embeddings, allow_dangerous_deserialization=True)
 
-# Get LLM model name from environment variable, with a default
+# 環境変数からLLMモデル名を取得、デフォルト値あり
 llm_model_name = os.getenv("LLM_MODEL_NAME", "gemini-2.0-flash-lite")
 
 llm = ChatGoogleGenerativeAI(
     model=llm_model_name,
     temperature=0,
     google_api_key=google_api_key
-) # Or "gemini-1.5-flash", "gemini-1.5-pro" for higher capabilities
+) # またはより高性能な "gemini-1.5-flash"、"gemini-1.5-pro"
 
 DATA_CLEARED_MESSAGE = "データが正常にクリアされました。"
 
@@ -49,7 +49,7 @@ class MyState(TypedDict, total=False):
     input: str                       # ユーザーの問い合わせ
     condition: Optional[str]         # 各ノードの実行状態
     intent_list: List[str]           # 分類結果（データ取得/グラフ作成/データ解釈）
-    latest_df: Optional[collections.OrderedDict[str, list]] # Changed: Dict mapping requirement to its dataframe (list of records)
+    latest_df: Optional[collections.OrderedDict[str, list]] # 変更：要件をそのデータフレーム（レコードのリスト）にマッピングする辞書
     df_history: Optional[List[dict]] # SQL実行結果のDataFrameの履歴 {"id": str, "query": str, "timestamp": str, "dataframe_dict": list, "SQL": Optional[str]}
     SQL: Optional[str]               # 生成されたSQL
     interpretation: Optional[str]    # データ解釈（分析コメント）
@@ -58,15 +58,15 @@ class MyState(TypedDict, total=False):
     error: Optional[str]             # SQL等でエラーがあれば
     query_history: Optional[List[str]] # ユーザーの問い合わせ履歴
     data_requirements: List[str]     # データ要件
-    missing_data_requirements: Optional[List[str]] # New: List of data requirements not found in history
+    missing_data_requirements: Optional[List[str]] # 新規：履歴に見つからなかったデータ要件のリスト
     clarification_question: Optional[str] = None
     analysis_options: Optional[List[str]] = None
     user_clarification: Optional[str] = None
-    analysis_plan: Optional[List[dict]] = None # Stores the list of analysis steps, e.g., [{"action": "sql", "details": "Overall monthly sales"}, {"action": "interpret", "details": "Interpret monthly sales data"}]
-    current_plan_step_index: Optional[int] = None # Index of the current step in analysis_plan
-    awaiting_step_confirmation: Optional[bool] = None # True if waiting for user to proceed to next step
-    complex_analysis_original_query: Optional[str] = None # Stores the original multi-step query
-    user_action: Optional[str] = None # New field for frontend actions like "proceed_analysis_step" or "cancel_analysis_plan"
+    analysis_plan: Optional[List[dict]] = None # 分析ステップのリストを格納します。例：[{"action": "sql", "details": "全体の月次売上"}, {"action": "interpret", "details": "月次売上データを解釈"}]
+    current_plan_step_index: Optional[int] = None # analysis_plan内の現在のステップのインデックス
+    awaiting_step_confirmation: Optional[bool] = None # ユーザーが次のステップに進むのを待っている場合はTrue
+    complex_analysis_original_query: Optional[str] = None # 元の複数ステップのクエリを格納します
+    user_action: Optional[str] = None # "proceed_analysis_step"や"cancel_analysis_plan"のようなフロントエンドアクション用の新しいフィールド
 
 #ユーザーの入力に応じて意図を分類
 def classify_intent_node(state: MyState):
@@ -145,7 +145,7 @@ def clear_data_node(state: MyState):
         "query_history": []
     }
     
-# New Analysis Planning Node (create_analysis_plan_node)
+# 新しい分析計画ノード (create_analysis_plan_node)
 def create_analysis_plan_node(state: MyState) -> MyState:
     user_query = state.get("input", "")
     user_clarification = state.get("user_clarification")
@@ -194,7 +194,7 @@ def create_analysis_plan_node(state: MyState) -> MyState:
             "analysis_plan": None,
             "current_plan_step_index": None,
             "user_clarification": None,
-            "condition": "plan_generation_failed",
+            "condition": "計画生成失敗",
             "error": f"分析計画の保存中にエラーが発生しました。: {e}"
         }
 
@@ -214,7 +214,7 @@ def create_analysis_plan_node(state: MyState) -> MyState:
             "analysis_plan": None,
             "current_plan_step_index": None,
             "user_clarification": None,
-            "condition": "plan_generation_failed",
+            "condition": "計画生成失敗",
             "error": f"分析計画の形式や内容に不備があります: {e}"
         }
 
@@ -230,7 +230,7 @@ def create_analysis_plan_node(state: MyState) -> MyState:
         "current_plan_step_index": 0 if parsed_plan else None,
         "awaiting_step_confirmation": False,
         "user_clarification": None,
-        "condition": "plan_generated" if parsed_plan else "empty_plan_generated",
+        "condition": "計画生成完了" if parsed_plan else "計画空で完了",
         "error": None
     }
 
@@ -240,7 +240,7 @@ def clarify_node(state: MyState) -> MyState:
     analysis_plan = state.get("analysis_plan", [])
     if current_plan_step_index is None or not analysis_plan or not (0 <= current_plan_step_index < len(analysis_plan)):
         logging.error("clarify_node:分析プランの状態が不正です。")
-        return {**state, "error": "分析プランの状態が不正です。", "condition": "clarify_error_invalid_plan"}
+        return {**state, "error": "分析プランの状態が不正です。", "condition": "明確化エラー無効計画"}
 
     current_step = analysis_plan[current_plan_step_index]
     action = current_step.get("action")
@@ -255,19 +255,19 @@ def clarify_node(state: MyState) -> MyState:
             **state,
             "clarification_question": clarification_question_from_plan,
             "user_clarification": None,
-            "condition": "awaiting_user_clarification"
+            "condition": "ユーザー明確化待ち"
         }
     else:
         logging.error(f"clarify_node: 想定外のアクションが渡されました。アクションの内容はこちらです。'{action}'")
         return {
             **state,
             "error": f"想定外のアクションが渡されました。アクションの内容はこちらです。 {action}",
-            "condition": "clarify_error_unexpected_action"
+            "condition": "明確化エラー予期せぬアクション"
         }
 
 # 追加質問をした際に、実行をキャンセルした際のノード
 def cancel_analysis_plan_node(state: MyState) -> MyState:
-    original_query = state.get("complex_analysis_original_query", "The analysis plan was cancelled.")
+    original_query = state.get("complex_analysis_original_query", "分析計画はキャンセルされました。")
     return {
         **state,
         "analysis_plan": None,
@@ -275,8 +275,8 @@ def cancel_analysis_plan_node(state: MyState) -> MyState:
         "awaiting_step_confirmation": False,
         "complex_analysis_original_query": None,
         "input": original_query,
-        "interpretation": "The multi-step analysis plan has been cancelled by the user.",
-        "condition": "plan_cancelled",
+        "interpretation": "複数ステップの分析計画はユーザーによってキャンセルされました。",
+        "condition": "計画キャンセル済",
         "user_action": None
     }
 
@@ -291,7 +291,7 @@ def check_history_node(state: MyState) -> MyState:
             **state,
             "latest_df": collections.OrderedDict(),
             "missing_data_requirements": [],
-            "condition": "history_checked_invalid_plan_or_index",
+            "condition": "履歴確認エラー無効計画インデックス",
             "error": "過去のデータをチェックしようとしましたが分析プランがありませんでした。"
         }
 
@@ -312,14 +312,14 @@ def check_history_node(state: MyState) -> MyState:
             **state,
             "latest_df": collections.OrderedDict(),
             "missing_data_requirements": safe_details_for_error_msg,
-            "condition": "history_checked_invalid_plan_or_index",
-            "error": f"Invalid current_plan_step_index ({current_plan_step_index}) for analysis_plan length ({len(analysis_plan) if analysis_plan else 0}) in check_history_node."
+            "condition": "履歴確認エラー無効計画インデックス",
+            "error": f"check_history_nodeにおいて、analysis_planの長さ ({len(analysis_plan) if analysis_plan else 0}) に対してcurrent_plan_step_index ({current_plan_step_index}) が無効です。"
         }
 
     # df_historyを取得する
     df_history = state.get("df_history", [])
     data_requirements_for_step = []
-    current_step_details = state.get("input") # This is set by execute_plan_router to current_step["details"]
+    current_step_details = state.get("input") # これはexecute_plan_routerによってcurrent_step["details"]に設定されます
 
     # inputが文字列の場合はリスト化、リストならそのまま
     if isinstance(current_step_details, str):
@@ -346,7 +346,7 @@ def check_history_node(state: MyState) -> MyState:
             **state,
             "latest_df": collections.OrderedDict(),
             "missing_data_requirements": [],
-            "condition": "history_checked_no_requirements",
+            "condition": "履歴確認エラー要件なし",
             "SQL": None, "interpretation": None, "chart_result": None
         }
 
@@ -376,7 +376,7 @@ def check_history_node(state: MyState) -> MyState:
         **state,
         "latest_df": found_data_map,
         "missing_data_requirements": missing_requirements,
-        "condition": "history_checked",
+        "condition": "履歴確認完了",
         "SQL": None, "interpretation": None, "chart_result": None
     }
 
@@ -475,9 +475,9 @@ def sql_node(state: MyState) -> MyState:
         logging.info("sql_node: 取得すべき要件が見つからなかったためSQLの作成・実行をスキップします。")
         return {
             **state,
-            "condition": "sql_execution_skipped_no_reqs",
+            "condition": "SQL実行スキップ要件なし",
             "SQL": None,
-            "error": "No requirements provided for SQL execution."
+            "error": "SQL実行のための要件が提供されていません。"
         }
 
     # latest_dfは必ずOrderedDictにして、すでにデータがあれば引き継ぐ
@@ -561,13 +561,13 @@ def sql_node(state: MyState) -> MyState:
 
     # 最終的なconditionを判定
     if not requirements_to_fetch: 
-        final_condition = "sql_execution_skipped_no_reqs"
+        final_condition = "SQL実行スキップ要件なし"
     elif not successfully_fetched_reqs and any_error_occurred: # SQLが全部失敗
-        final_condition = "sql_execution_failed"
+        final_condition = "SQL実行失敗"
     elif any_error_occurred: # 一部成功・一部失敗
-        final_condition = "sql_execution_partial_success"
+        final_condition = "SQL実行一部成功"
     else: #全取得成功
-        final_condition = "sql_execution_done"
+        final_condition = "SQL実行完了"
 
     # 取得できなかったものだけmissing_data_requirementsとして再セット
     current_missing_reqs_in_state = state.get("missing_data_requirements", [])
@@ -586,19 +586,19 @@ def sql_node(state: MyState) -> MyState:
 def interpret_node(state: MyState) -> MyState:
     latest_df_data = state.get("latest_df")
     # 解釈用の文脈は state.input（execute_plan_router が plan step details からセット）を利用
-    plan_details_context = state.get("input", "全般的な傾向") # Default if no specific detail
+    plan_details_context = state.get("input", "全般的な傾向") # 特定の詳細がない場合のデフォルト
 
     if latest_df_data is None:
         logging.info("interpret_node: latest_dfがNoneのため、解釈できるデータがありません。")
-        return {**state, "interpretation": "解釈するデータがありません。", "condition": "interpretation_failed_no_data"}
+        return {**state, "interpretation": "解釈するデータがありません。", "condition": "解釈失敗データなし"}
 
     if not isinstance(latest_df_data, collections.OrderedDict):
         logging.error(f"interpret_node: latest_dfの型がOrderedDictではありません (type: {type(latest_df_data)}).")
-        return {**state, "interpretation": "データの形式が不正です (OrderedDictではありません)。", "condition": "interpretation_failed_bad_format"}
+        return {**state, "interpretation": "データの形式が不正です (OrderedDictではありません)。", "condition": "解釈失敗不正形式"}
 
     if not latest_df_data: # Check if the OrderedDict is empty
         logging.info("interpret_node: latest_dfが空（データ無し）です。")
-        return {**state, "interpretation": "解釈するデータが空です。", "condition": "interpretation_failed_empty_data"}
+        return {**state, "interpretation": "解釈するデータが空です。", "condition": "解釈失敗空データ"}
 
     full_data_string = ""
     
@@ -629,7 +629,7 @@ def interpret_node(state: MyState) -> MyState:
 
     if not full_data_string.strip() or (processed_parts and all_parts_indicate_no_data):
         logging.info("interpret_node: データ内容が全て空またはエラーのため、解釈対象がありません。")
-        return {**state, "interpretation": "解釈対象の有効なデータがありませんでした。", "condition": "interpretation_failed_empty_data"}
+        return {**state, "interpretation": "解釈対象の有効なデータがありませんでした。", "condition": "解釈失敗空データ"}
 
     system_prompt = "あなたは優秀なデータ分析の専門家です。"
     user_prompt = f"""
@@ -647,14 +647,14 @@ def interpret_node(state: MyState) -> MyState:
 
         if not interpretation_text:
             logging.warning("interpret_node: LLM returned empty interpretation.")
-            final_condition = "interpretation_failed"
+            final_condition = "解釈失敗"
             interpretation_text = "解釈の生成に失敗しました。"
         else:
-            final_condition = "interpretation_done"
+            final_condition = "解釈完了"
     except Exception as e:
         logging.error(f"interpret_node: Exception during LLM call: {e}")
         interpretation_text = "解釈中にエラーが発生しました。"
-        final_condition = "interpretation_failed"
+        final_condition = "解釈失敗"
     return {**state, "interpretation": interpretation_text, "condition": final_condition}
 
 
@@ -663,8 +663,8 @@ def chart_node(state: MyState) -> MyState:
     # Charting instructions from plan step details, now in state.input
     chart_instructions = state.get("input", "Generate a suitable chart for the available data.")
 
-    if not latest_df_data or not isinstance(latest_df_data, collections.OrderedDict) or not any(v for v in latest_df_data.values() if v): # ensure at least one df has data
-        return {**state, "chart_result": None, "condition": "chart_generation_failed_no_data"}
+    if not latest_df_data or not isinstance(latest_df_data, collections.OrderedDict) or not any(v for v in latest_df_data.values() if v): # 少なくとも1つのDFにデータがあることを確認してください
+        return {**state, "chart_result": None, "condition": "グラフ生成失敗データなし"}
 
     df_to_plot = None
     selected_key_for_chart = None
@@ -672,7 +672,7 @@ def chart_node(state: MyState) -> MyState:
     # Attempt to select DataFrame based on chart_instructions referencing a key
     if isinstance(chart_instructions, str):
         for key in latest_df_data.keys():
-            # Ensure data for the key is not empty before considering it a match
+            # キーのデータが空でないことを確認してから一致と見なします
             if latest_df_data.get(key) and isinstance(latest_df_data[key], list) and len(latest_df_data[key]) > 0 and key.lower() in chart_instructions.lower():
                 selected_key_for_chart = key
                 break
@@ -685,12 +685,12 @@ def chart_node(state: MyState) -> MyState:
                 chart_context_message = f"以下の「{selected_key_for_chart}」に関するデータと、ユーザーからの「{chart_instructions}」という指示に基づいて"
             else:
                 logging.warning(f"chart_node: DataFrame for selected key '{selected_key_for_chart}' is empty.")
-                selected_key_for_chart = None # Nullify to trigger fallback
+                selected_key_for_chart = None # フォールバックをトリガーするために無効化します
         except Exception as e:
             logging.error(f"chart_node: Error creating DataFrame for selected key '{selected_key_for_chart}': {e}")
-            selected_key_for_chart = None # Nullify to trigger fallback
+            selected_key_for_chart = None # フォールバックをトリガーするために無効化します
 
-    if df_to_plot is None: # Fallback: use the first non-empty DataFrame
+    if df_to_plot is None: # フォールバック：最初の空でないDataFrameを使用します
         for key, data_list in latest_df_data.items():
             if data_list and isinstance(data_list, list) and len(data_list) > 0:
                 try:
@@ -699,7 +699,7 @@ def chart_node(state: MyState) -> MyState:
                         df_to_plot = df_candidate
                         selected_key_for_chart = key
                         chart_context_message = f"以下の「{selected_key_for_chart}」に関するデータ（複数あるデータセットの最初で、有効なデータを含むもの）と、ユーザーからの「{chart_instructions}」という指示に基づいて"
-                        if len(latest_df_data) > 1 and (not isinstance(chart_instructions, str) or selected_key_for_chart.lower() not in chart_instructions.lower()): # Check if chart_instructions is not str OR selected_key not in chart_instructions
+                        if len(latest_df_data) > 1 and (not isinstance(chart_instructions, str) or selected_key_for_chart.lower() not in chart_instructions.lower()): # chart_instructionsが文字列でないか、selected_keyがchart_instructionsに含まれていないかを確認します
                             logging.warning(f"chart_node: Multiple DataFrames available. Defaulting to first non-empty one ('{selected_key_for_chart}') due to generic or non-matching chart instructions: '{chart_instructions}'.")
                         break
                 except Exception as e:
@@ -707,7 +707,7 @@ def chart_node(state: MyState) -> MyState:
                     continue
 
     if df_to_plot is None or df_to_plot.empty:
-        return {**state, "chart_result": None, "condition": "chart_generation_failed_empty_selected_data", "error": "チャート作成に適したデータが見つかりませんでした。"}
+        return {**state, "chart_result": None, "condition": "グラフ生成失敗空選択データ", "error": "チャート作成に適したデータが見つかりませんでした。"}
 
     python_tool = PythonAstREPLTool(
         locals={"df": df_to_plot, "sns": sns, "pd": pd, "japanize_matplotlib": japanize_matplotlib},
@@ -719,7 +719,7 @@ def chart_node(state: MyState) -> MyState:
     tools = [python_tool]
     agent = initialize_agent(
         tools, llm, agent="zero-shot-react-description", verbose=True, handle_parsing_errors=True,
-        agent_kwargs={"handle_parsing_errors": True} # Added for more robust error handling if LLM output is bad for agent
+        agent_kwargs={"handle_parsing_errors": True} # LLMの出力がエージェントにとって不適切だった場合のより堅牢なエラー処理のために追加
     )
 
     chart_prompt = f"""
@@ -741,28 +741,28 @@ def chart_node(state: MyState) -> MyState:
 
         if os.path.exists("output.png"):
             fig = base64.b64encode(open("output.png", "rb").read()).decode('utf-8')
-            return {**state, "chart_result": fig, "condition": "chart_generation_done"}
+            return {**state, "chart_result": fig, "condition": "グラフ生成完了"}
         else:
             logging.error("chart_node: Agent executed but output.png was not found. Agent output might indicate why.")
-            error_message = "グラフファイルの生成に失敗しました。"
+            error_message = "エージェントは実行されましたが、output.pngが見つかりませんでした。エージェントの出力が理由を示している可能性があります。"
             if isinstance(agent_response, dict) and "output" in agent_response:
                 error_message += f" (Agent: {agent_response['output']})"
-            return {**state, "chart_result": None, "condition": "chart_generation_failed_no_output_file", "error": error_message}
+            return {**state, "chart_result": None, "condition": "グラフ生成失敗出力ファイルなし", "error": error_message}
     except Exception as e:
         logging.error(f"chart_node: Error during agent execution: {e}", exc_info=True)
-        return {**state, "chart_result": None, "condition": "chart_generation_failed_agent_error", "error": str(e)}
+        return {**state, "chart_result": None, "condition": "グラフ生成失敗エージェントエラー", "error": f"グラフの生成に失敗しました: {e}"}
 
 def classify_next(state: MyState):
     user_action = state.get("user_action")
     intents = state.get("intent_list", [])
 
     if state.get("user_clarification"):
-        logging.info("classify_next: User clarification detected. Routing to dispatch_plan_step.")
-        return "dispatch_plan_step"
+        logging.info("classify_next: User clarification detected. Routing to execute_plan_route_step.")
+        return "execute_plan_route_step"
 
     if user_action == "proceed_analysis_step":
-        logging.info("classify_next: 'proceed_analysis_step' action. Routing to dispatch_plan_step.")
-        return "dispatch_plan_step"
+        logging.info("classify_next: 'proceed_analysis_step' action. Routing to execute_plan_route_step.")
+        return "execute_plan_route_step"
     elif user_action == "cancel_analysis_plan":
         logging.info("classify_next: 'cancel_analysis_plan' action. Routing to cancel_analysis_plan node.")
         return "cancel_analysis_plan"
@@ -773,17 +773,17 @@ def classify_next(state: MyState):
         return "metadata_retrieval"
 
     if state.get("analysis_plan") and state.get("current_plan_step_index") is not None:
-        logging.info("classify_next: Existing plan detected. Routing to dispatch_plan_step to continue.")
-        return "dispatch_plan_step"
+        logging.info("classify_next: Existing plan detected. Routing to execute_plan_route_step to continue.")
+        return "execute_plan_route_step"
     else:
         logging.info("classify_next: No existing plan or overriding action. Routing to create_analysis_plan.")
         return "create_analysis_plan"
 
 def clarify_next(state: MyState):
     condition = state.get("condition")
-    if condition == "awaiting_user_clarification":
+    if condition == "ユーザー明確化待ち": # awaiting_user_clarification
         return END
-    elif condition == "clarify_error_invalid_plan" or condition == "clarify_error_unexpected_action":
+    elif condition == "明確化エラー無効計画" or condition == "明確化エラー予期せぬアクション": # clarify_error_invalid_plan, clarify_error_unexpected_action
         return END
     else:
         logging.warning(f"clarify_next: Unexpected condition '{condition}' from clarify_node. Defaulting to END.")
@@ -791,13 +791,13 @@ def clarify_next(state: MyState):
 
 def create_analysis_plan_next(state: MyState):
     condition = state.get("condition")
-    if condition == "plan_generated":
-        logging.info("create_analysis_plan_next: Plan generated. Routing to dispatch_plan_step.")
-        return "dispatch_plan_step"
-    elif condition == "empty_plan_generated":
+    if condition == "計画生成完了": # plan_generated
+        logging.info("create_analysis_plan_next: Plan generated. Routing to execute_plan_route_step.")
+        return "execute_plan_route_step"
+    elif condition == "計画空で完了": # empty_plan_generated
         logging.info("create_analysis_plan_next: Empty plan generated. Routing to END")
         return END
-    elif condition == "plan_generation_failed":
+    elif condition == "計画生成失敗": # plan_generation_failed
         logging.error("create_analysis_plan_next: Plan generation failed. Routing to END.")
         return END
     else:
@@ -809,14 +809,14 @@ def check_history_next(state: MyState):
     if current_index is not None:
         state["current_plan_step_index"] = current_index + 1
     state["awaiting_step_confirmation"] = False
-    return "dispatch_plan_step"
+    return "execute_plan_route_step"
 
 def sql_next(state: MyState):
     current_index = state.get("current_plan_step_index")
     if current_index is not None:
         state["current_plan_step_index"] = current_index + 1
         state["awaiting_step_confirmation"] = False
-        return "dispatch_plan_step"
+        return "execute_plan_route_step"
     logging.warning("sql_next: SQL node executed outside of a planned context.")
     return END
 
@@ -825,7 +825,7 @@ def chart_next(state: MyState):
     if current_index is not None:
         state["current_plan_step_index"] = current_index + 1
         state["awaiting_step_confirmation"] = False
-        return "dispatch_plan_step"
+        return "execute_plan_route_step"
     logging.warning("chart_next: Chart node executed outside of a planned context.")
     return END
 
@@ -834,7 +834,7 @@ def interpret_next(state: MyState):
     if current_index is not None:
         state["current_plan_step_index"] = current_index + 1
         state["awaiting_step_confirmation"] = False
-        return "dispatch_plan_step"
+        return "execute_plan_route_step"
     logging.warning("interpret_next: Interpret node executed outside of a planned context.")
     return END
 
@@ -891,7 +891,7 @@ def build_workflow():
     workflow.add_node("classify", classify_intent_node)
     workflow.add_node("create_analysis_plan", create_analysis_plan_node)
     workflow.add_node("cancel_analysis_plan", cancel_analysis_plan_node)
-    workflow.add_node("dispatch_plan_step", lambda state: state) # New dummy node for central routing logic
+    workflow.add_node("execute_plan_route_step", lambda state: state) # 中央ルーティングロジック用の新しいダミーノード
     workflow.add_node("clarify", clarify_node)
     workflow.add_node("check_history", check_history_node)
     workflow.add_node("sql", sql_node)
@@ -909,7 +909,7 @@ def build_workflow():
     workflow.add_conditional_edges("create_analysis_plan", create_analysis_plan_next)
 
     workflow.add_conditional_edges(
-        "dispatch_plan_step",
+        "execute_plan_route_step",
         execute_plan_router,
         {
             "create_analysis_plan": "create_analysis_plan",
@@ -926,31 +926,31 @@ def build_workflow():
         "sql",
         sql_next,
         {
-            "dispatch_plan_step": "dispatch_plan_step",
-            END: END  # Explicitly map END if it's a possible return
+            "execute_plan_route_step": "execute_plan_route_step",
+            END: END  # 考えられる戻り値の場合はENDを明示的にマッピングします
         }
     )
     workflow.add_conditional_edges(
         "chart",
         chart_next,
         {
-            "dispatch_plan_step": "dispatch_plan_step",
-            END: END # Explicitly map END if it's a possible return (though not in current chart_next)
+            "execute_plan_route_step": "execute_plan_route_step",
+            END: END # 考えられる戻り値の場合はENDを明示的にマッピングします (現在のchart_nextにはありませんが)
         }
     )
     workflow.add_conditional_edges(
         "interpret",
         interpret_next,
         {
-            "dispatch_plan_step": "dispatch_plan_step",
-            END: END # Explicitly map END if it's a possible return (though not in current interpret_next)
+            "execute_plan_route_step": "execute_plan_route_step",
+            END: END # 考えられる戻り値の場合はENDを明示的にマッピングします (現在のinterpret_nextにはありませんが)
         }
     )
     workflow.add_conditional_edges(
         "check_history",
         check_history_next,
         {
-            "dispatch_plan_step": "dispatch_plan_step"
+            "execute_plan_route_step": "execute_plan_route_step"
             # If check_history_next could return other values, map them here.
             # For now, it only returns "dispatch_plan_step".
         }
@@ -960,7 +960,7 @@ def build_workflow():
         clarify_next,
         {
             END: END
-            # clarify_next always returns END or conditions that should lead to END.
+            # clarify_nextは常にENDまたはENDにつながるべき条件を返します。
         }
     )
 


### PR DESCRIPTION
This commit addresses issue #<issue_id> (if available, otherwise omit this) by implementing the following changes:

1.  **Internationalization (i18n):**
    *   Translated English comments and error messages in `files/backend_codes.py` to Japanese to improve code comprehension for Japanese-speaking developers.
    *   Translated `MyState` condition strings in `files/backend_codes.py` to Japanese, ensuring all graph logic correctly uses the new translated conditions.
    *   Translated user-facing English text in `files/front_codes.py` (e.g., button labels, messages, placeholders) to Japanese for a better user experience for Japanese users.

2.  **Node Renaming:**
    *   Renamed the graph node `dispatch_plan_step` to `execute_plan_route_step` in `files/backend_codes.py` for improved clarity in the graph's structure. All associated edge definitions and return values in routing functions were updated accordingly.

3.  **Test Updates:**
    *   Modified `files/test_backend_codes.py` to update assertions that previously checked for English condition strings or error messages. These tests now correctly assert against the new Japanese translations, ensuring continued test coverage.

These changes aim to make the codebase more accessible and maintainable for its target users and developers.