### PR TITLE
Update backend_codes.py

### DIFF
--- a/files/backend_codes.py
+++ b/files/backend_codes.py
@@ -35,7 +35,7 @@ deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
 # # 環境変数からLLMモデル名を取得します（デフォルト値あり）
 # llm_model_name = os.getenv("LLM_MODEL_NAME", "gemini-1.5-flash") # デフォルトをgemini-1.5-proに変更
 # google_api_key = os.getenv("GOOGLE_API_KEY")
-# embeddings = GoogleGenerativeAIEmbeddings(model="models/embedding-001", google_api_key=google_api_key) 
+# embeddings = GoogleGenerativeAIEmbeddings(model="models/embedding-001", google_api_key=google_api_key)
 # llm = ChatGoogleGenerativeAI(
 #     model=llm_model_name,
 #     temperature=0,
@@ -65,7 +65,7 @@ vectorstore_queries = FAISS.load_local("faiss_queries", embeddings, allow_danger
 class AgentState(TypedDict):
     messages: Annotated[List[BaseMessage], lambda x, y: x + y]
     next: str  # 次に実行すべきノード名
-    df_history: List[dict] 
+    df_history: List[dict]
 
 history_back_number = 5
 RERANK_CANDIDATE_COUNT = 5
@@ -95,7 +95,7 @@ def metadata_retrieval_node(task_description: str, conversation_history: list[st
 
     【現在のタスク】
     {task_description}
-    
+
     【ユーザーの全体的な質問の文脈】
     {context}
 
@@ -123,7 +123,7 @@ def analysis_plan_node(task_description: str, conversation_history: list[str]):
     logging.info(f"analysis_plan_node: RAG情報を読み込み中 '{task_description}'")
     retrieved_docs = vectorstore_tables.similarity_search(task_description)
     retrieved_table_info = "\n\n".join([doc.page_content for doc in retrieved_docs])
-    
+
     prompt_template = """
     以下の情報を参照して、ユーザーの質問に答えるための分析計画を立ててください。
 
@@ -132,7 +132,7 @@ def analysis_plan_node(task_description: str, conversation_history: list[str]):
 
     【現在のタスク】
     {task_description}
-    
+
     【ユーザーの全体的な質問の文脈】
     {context}
 
@@ -144,35 +144,55 @@ def analysis_plan_node(task_description: str, conversation_history: list[str]):
     step_answer = response.content.strip()
 
     return step_answer
-    
+
 def sql_node(state: AgentState):
     """
     自然言語のタスク記述とstate内の会話履歴を受け取り、ルールを強く意識した上でSQLを生成・実行します。
     （二段階選抜とルール遵守CoTを実装）
     """
     try:
-        task_description = state["messages"][-1].content
-        tool_call_id = state["messages"][-2].tool_calls[0]['id']
+        # --- 修正: スーパーバイザーからの指示の受け取り方 ---
+        supervisor_ai_message = state["messages"][-1]
+        if not isinstance(supervisor_ai_message, AIMessage) or not supervisor_ai_message.tool_calls:
+            error_message_payload = {"status": "error", "error_message": "不正な呼び出し形式です。スーパーバイザーからのAIMessage(tool_calls付き)が見つかりません。"}
+            logging.error(f"sql_node: {error_message_payload['error_message']}")
+            return {"messages": [ToolMessage(content=json.dumps(error_message_payload), tool_call_id=None)]}
+
+        first_tool_call = supervisor_ai_message.tool_calls[0]
+        tool_call_id = first_tool_call['id']
+
+        arguments_json = first_tool_call['function']['arguments']
+        arguments = json.loads(arguments_json)
+
+        task_description = arguments.get('task_description')
+        if task_description is None:
+            error_message_payload = {"status": "error", "error_message": "task_descriptionがスーパーバイザーの指示に含まれていません。"}
+            logging.error(f"sql_node: {error_message_payload['error_message']}")
+            return {"messages": [ToolMessage(content=json.dumps(error_message_payload), tool_call_id=tool_call_id)]}
+        # --- 修正ここまで ---
+
         conversation_history = state.get("messages", [])
         non_system_history = [msg for msg in conversation_history if msg.type != "system"]
         recent_history = non_system_history[-history_back_number:]
         context = "\n".join([f"{msg.type}: {msg.content}" for msg in recent_history])
-    except (IndexError, KeyError):
-        error_message = {"status": "error", "error_message": "不正な呼び出し形式です。"}
-        return {"messages": [ToolMessage(content=json.dumps(error_message), tool_call_id=None)]}
+
+    except (IndexError, KeyError, json.JSONDecodeError, AttributeError, ValueError) as e:
+        error_message_detail = f"ノード初期化エラー: {e}. Messages: {state.get('messages')}"
+        logging.error(f"sql_node: {error_message_detail}")
+        current_tool_call_id = locals().get("tool_call_id", None) # tool_call_idが取得できていればそれを使う
+        error_message_payload = {"status": "error", "error_message": error_message_detail}
+        return {"messages": [ToolMessage(content=json.dumps(error_message_payload), tool_call_id=current_tool_call_id)]}
 
     # ★ --- 1. 候補となるテーブルを多めに取得（Re-rankingステップ） ---
     logging.info(f"sql_node(Re-rank): 候補テーブルを広く検索中 (k=RERANK_CANDIDATE_COUNT)...")
-    # vectorstore_tablesには、format_table_schema_for_llmで変換済みのテキストが格納されている想定
-    candidate_docs = vectorstore_tables.similarity_search(task_description, k=RERANK_CANDIDATE_COUNT)        
+    candidate_docs = vectorstore_tables.similarity_search(task_description, k=RERANK_CANDIDATE_COUNT)
     candidate_table_names = [get_table_name_from_formatted_doc(doc.page_content) for doc in candidate_docs]
     candidate_tables_info_for_prompt = "\n\n".join(
-        # 選別用プロンプトでは、ルールも見えるようにそのままのテキストを渡す
-        [doc.page_content for name, doc in zip(candidate_table_names, candidate_docs) if name] 
+        [doc.page_content for name, doc in zip(candidate_table_names, candidate_docs) if name]
     )
 
     # ★ --- 2. LLMにテーブルを選別させる（1回目の問いかけ） ---
-    if candidate_tables_info_for_prompt: # 候補がある場合のみ選別
+    if candidate_tables_info_for_prompt:
         logging.info(f"sql_node(Re-rank): LLMにテーブル選別を依頼中...")
         rerank_prompt = f"""
         ユーザーの最終的な要求は「{task_description}」です。
@@ -186,23 +206,22 @@ def sql_node(state: AgentState):
         """
         rerank_response = llm.invoke(rerank_prompt)
         required_table_names_str = rerank_response.content.strip()
-        if required_table_names_str: # LLMが何かしらテーブル名を返した場合
+        if required_table_names_str:
              required_table_names = [name.strip() for name in required_table_names_str.split(',')]
-        else: # LLMがテーブル名を選べなかった場合、元の候補を全て使うか、エラーにするか検討。ここでは全て使う。
+        else:
             logging.warning("LLMが選別するテーブル名を返さなかったため、検索候補を全て使用します。")
-            required_table_names = [name for name in candidate_table_names if name] # Noneを除外
+            required_table_names = [name for name in candidate_table_names if name]
 
         logging.info(f"sql_node(Re-rank): LLMが選別したテーブル: {required_table_names}")
-    else: # RAG検索で候補が一つもなかった場合
+    else:
         logging.warning("RAG検索でテーブル候補が見つかりませんでした。")
         required_table_names = []
-
 
     # ★ --- 3. LLMの選別結果を基に、使用するテーブル定義を絞り込む ---
     final_docs = [doc for doc in candidate_docs if get_table_name_from_formatted_doc(doc.page_content) in required_table_names]
     final_rag_tables_text = "\n\n".join([doc.page_content for doc in final_docs])
 
-    if not final_rag_tables_text: # 最終的に使用するテーブル情報がない場合はエラー
+    if not final_rag_tables_text:
         logging.error("sql_node: 最終的に使用するテーブル情報が見つかりませんでした。")
         result_payload = {"status": "error", "error_message": "関連するテーブル情報が見つかりませんでした。"}
         return {"messages": [ToolMessage(content=json.dumps(result_payload), tool_call_id=tool_call_id)]}
@@ -212,42 +231,42 @@ def sql_node(state: AgentState):
     あなたは非常に優秀なSQL生成AIです。ユーザーの要求、提供されたテーブル定義、
     そして最も重要な【テーブル全体に関するルール】（<table_explanation>タグ内）と
     各【カラム定義と個別ルール】（<column>タグ内の<explanation>タグ）を基に、SQLiteのSQLを生成します。
-    
+
     SQLを生成する前に、必ず以下の思考プロセスに従って、ステップバイステップで考察を行ってください。
     あなたの最終的な出力は、思考プロセスを含まない、実行可能なSQLite SQLクエリ文のみにしてください。
     ---
     ### 思考プロセス (Chain-of-Thought)
-    
+
     1.  **ユーザー要求の理解**: ユーザーが最終的に何を知りたいのかを明確にする。
-    
+
     2.  **使用テーブルの確認とルール遵守**:
         * 今回使用するテーブルは、提供された【使用するテーブル定義】の中から最も適切なものを1つだけ選択する。
         * 選択したテーブルの【テーブル全体に関するルール】（<table_explanation>の内容）を特定し、このルールをSQL生成時にどのように考慮するか記述する。
-    
+
     3.  **使用カラムの特定とルールチェック**:
         テーブル内のカラムについて【カラム定義と個別ルール】（<column>タグ内の<explanation>の内容）を確認します。以下のチェックリスト形式で思考を整理してください。ルールがない場合は「特になし」と記載する。
-    
+
         | 使用するカラム名 | カラムの個別ルール                                     | ルールをSQLにどう反映させるか（SELECT句、WHERE句など） |
         | :--------------- | :----------------------------------------------------- | :----------------------------------------------------- |
         | (例) カテゴリ    | 必ず出力に含めてください。指定がない場合はWhere句で’All’ | SELECT句に「カテゴリ」を含める。WHERE句の条件を確認。 |
         | ...              | ...                                                    | ...                                                    |
-    
+
     4.  **SQL組み立て方針の決定**:
         * `SELECT`句: 上記のルールチェックに基づき、どのカラムを含めるか。
         * `FROM`句: ステップ2で確認したテーブル名。
         * `WHERE`句: 上記のルールチェックとユーザー要求に基づき、どのような条件が必要か。
         * その他（`GROUP BY`, `ORDER BY`, `LIMIT`）: 必要に応じて。ただし、テーブル全体のルール（例：集計関数禁止など）やSQLiteの制約（JOIN禁止、単一テーブル使用）を厳守する。
-    
+
     5.  **最終SQLの生成**: 上記の方針に基づき、最終的なSQLite SQLクエリを生成する。ルール違反がないか最終確認する。
     ---
-    
+
     上記の思考プロセスを頭の中で実行し、完成したSQLクエリのみを出力してください。
     SQLの前後にコメントや説明文は出力しないでください。
     使用できるSQL構文は「SELECT」「WHERE」「GROUP BY」「ORDER BY」「LIMIT」のみです。
     日付関数や高度な型変換、サブクエリやウィンドウ関数、JOINは使わないでください。
     必ず1つのテーブルだけを使い、簡単な集計・フィルタ・並べ替えまでにしてください。
     """
-    
+
     # --- 5. 本番のSQL生成用ユーザープロンプトを組み立てる ---
     retrieved_queries_docs = vectorstore_queries.similarity_search(task_description, k=3)
     rag_queries = "\n\n".join([doc.page_content for doc in retrieved_queries_docs])
@@ -255,19 +274,19 @@ def sql_node(state: AgentState):
     user_prompt = f"""
     【現在のタスク】
     {task_description}
-    
+
     【ユーザーの全体的な質問の文脈】
     {context}
-    
+
     【使用するテーブル定義】
     {final_rag_tables_text}
-    
+
     【類似する問い合わせ例とそのSQL】
     {rag_queries}
-    
+
     この要件を満たし、かつ提示された全てのルールを厳守するSQLite SQLクエリを生成してください。
     """
-
+    new_history_item = {} # tryブロックの外で参照できるように初期化
     # --- 6. SQL生成の実行と後続処理（2回目の問いかけ & 実行） ---
     try:
         logging.info(f"sql_node(CoT): 生成AIが考えています・・・ '{task_description}'")
@@ -290,18 +309,20 @@ def sql_node(state: AgentState):
                 result_payload = {"status": "error", "error_message": str(sql_error), "last_attempted_sql": last_sql_generated}
             else:
                 result_payload = {"status": "success", "executed_sql": last_sql_generated, "dataframe_as_json": result_df.to_json(orient="records")}
-                new_history_item = {task_description: result_df.to_dict(orient="records")} if not result_df.empty else {}
+                if result_df is not None and not result_df.empty:
+                     new_history_item = {task_description: result_df.to_dict(orient="records")}
         else:
             result_payload = {"status": "success", "executed_sql": last_sql_generated, "dataframe_as_json": result_df.to_json(orient="records")}
-            new_history_item = {task_description: result_df.to_dict(orient="records")} if not result_df.empty else {}
+            if result_df is not None and not result_df.empty:
+                new_history_item = {task_description: result_df.to_dict(orient="records")}
     except Exception as e:
         logging.error(f"sql_nodeで予期せぬエラー: {e}")
         result_payload = {"status": "error", "error_message": f"SQLノードの実行中に予期せぬエラーが発生しました: {e}", "last_attempted_sql": locals().get("last_sql_generated", "N/A")}
-    
-    current_df_history = state.get("df_history", [])
-    if new_history_item: # 成功した場合のみ履歴に追加
-        current_df_history.append(new_history_item)
-    # 状態を直接いじる代わりに、結果をメッセージとして返す
+
+    updated_df_history = state.get("df_history", [])
+    if new_history_item: # 成功した場合のみ履歴に追加 (空の辞書でないことを確認)
+        updated_df_history = updated_df_history + [new_history_item]
+
     return {
         "messages": [
             ToolMessage(
@@ -309,7 +330,7 @@ def sql_node(state: AgentState):
                 tool_call_id=tool_call_id
             )
         ],
-        "df_history": state.get("df_history", []) + [new_history_item]
+        "df_history": updated_df_history
     }
 
 # 解釈ノード
@@ -319,59 +340,84 @@ def interpret_node(state: AgentState):
     分析のためにデータを解釈する必要がある際に使用します。
     """
     try:
-        task_description = state["messages"][-1].content
-        tool_call_id = state["messages"][-2].tool_calls[0]['id']
-    except (IndexError, KeyError):
-        error_message = "不正な呼び出し形式です。スーパーバイザーからの指示が正しくありません。"
-        # tool_call_idが不明なため、Noneを指定
-        return {"messages": [ToolMessage(content=error_message, tool_call_id=None)]}
+        # --- 修正: スーパーバイザーからの指示の受け取り方 ---
+        supervisor_ai_message = state["messages"][-1]
+        if not isinstance(supervisor_ai_message, AIMessage) or not supervisor_ai_message.tool_calls:
+            error_message = "不正な呼び出し形式です。スーパーバイザーからのAIMessage(tool_calls付き)が見つかりません。"
+            logging.error(f"interpret_node: {error_message}")
+            return {"messages": [ToolMessage(content=error_message, tool_call_id=None)]}
+
+        first_tool_call = supervisor_ai_message.tool_calls[0]
+        tool_call_id = first_tool_call['id']
+
+        arguments_json = first_tool_call['function']['arguments']
+        arguments = json.loads(arguments_json)
+
+        task_description = arguments.get('task_description')
+        if task_description is None:
+            error_message = "task_descriptionがスーパーバイザーの指示に含まれていません。"
+            logging.error(f"interpret_node: {error_message}")
+            return {"messages": [ToolMessage(content=error_message, tool_call_id=tool_call_id)]}
+        # --- 修正ここまで ---
+
+    except (IndexError, KeyError, json.JSONDecodeError, AttributeError, ValueError) as e:
+        error_message_detail = f"ノード初期化エラー: {e}. Messages: {state.get('messages')}"
+        logging.error(f"interpret_node: {error_message_detail}")
+        current_tool_call_id = locals().get("tool_call_id", None)
+        return {"messages": [ToolMessage(content=error_message_detail, tool_call_id=current_tool_call_id)]}
 
     logging.info(f"interpret_node: df_historyの読み込み開始・・・ '{task_description}'")
-    df_history = state.get("df_history", [])
-    if df_history is None:
-        raise RuntimeError("interpret_node: df_historyが空です。利用可能なデータがありません。")
+    df_history = state.get("df_history", []) # getのデフォルトを空リストに
+    if not df_history: # df_historyがNoneまたは空の場合
+        # RuntimeErrorを発生させる代わりに、ToolMessageでエラーを返す
+        error_message = "interpret_node: df_historyが空です。利用可能なデータがありません。"
+        logging.warning(error_message) # Warningレベルに変更
+        return {"messages": [ToolMessage(content=error_message, tool_call_id=tool_call_id)]}
+
     full_data_list = []
     for entry in df_history:
         for question, data in entry.items():
             try:
-                # DataFrame化
                 df = pd.DataFrame(data)
                 if not df.empty:
                     full_data_list.append(f"■「{question}」に関するデータ:\n{df.to_string(index=False)}\n\n")
                 else:
                     full_data_list.append(f"■「{question}」に関するデータ:\n(この要件に対するデータは空でした)\n\n")
-        
             except Exception as e:
                 logging.error(f"interpret_node: 'df_historyをDataFrameに変換中にエラーが発生しました: {e}")
                 full_data_list.append(f"■「{question}」に関するデータ:\n(データ形式エラーのため表示できません)\n\n")
     full_data_string = "".join(full_data_list)
 
-    # 全て空・エラーだった場合に備えたチェック
-    processed_parts = [part for part in full_data_string.split("■")[1:] if part]
-    all_parts_indicate_no_data = all(
-        "(この要件に対するデータはありませんでした)" in part or \
-        "(データ形式エラーのため表示できません)" in part or \
-        "(この要件に対するデータは空でした)" in part \
-        for part in processed_parts
-    )
+    processed_parts = [part for part in full_data_string.split("■")[1:] if part] # ""を除外
+    all_parts_indicate_no_data = False # 初期化
+    if not processed_parts: # 分割後が空（つまりfull_data_stringが空か「■」を含まない）
+        all_parts_indicate_no_data = True
+    else:
+        all_parts_indicate_no_data = all(
+            "(この要件に対するデータはありませんでした)" in part or \
+            "(データ形式エラーのため表示できません)" in part or \
+            "(この要件に対するデータは空でした)" in part
+            for part in processed_parts
+        )
+
     if all_parts_indicate_no_data:
-        raise RuntimeError("interpret_node: 利用可能なデータがありませんでした。")
-    
-    # システムメッセージ以外を抽出
+        # RuntimeErrorを発生させる代わりに、ToolMessageでエラーを返す
+        error_message = "interpret_node: 利用可能なデータがありませんでした（空またはエラー）。"
+        logging.warning(error_message) # Warningレベルに変更
+        return {"messages": [ToolMessage(content=error_message, tool_call_id=tool_call_id)]}
+
     conversation_history = state.get("messages", [])
     non_system_history = [msg for msg in conversation_history if msg.type != "system"]
-    # 直近N件だけ取り出し
     recent_history = non_system_history[-history_back_number:]
     context = "\n".join([f"{msg.type}: {msg.content}" for msg in recent_history])
 
     system_prompt = "あなたは優秀なデータ分析の専門家です。"
-
     user_prompt = f"""
     現在のタスクと文脈を踏まえて、データから読み取れる特徴や傾向を簡潔な日本語で解説してください。
-    
+
     【現在のタスク】
     {task_description}
-    
+
     【ユーザーの全体的な質問の文脈】
     {context}
 
@@ -387,14 +433,16 @@ def interpret_node(state: AgentState):
         interpretation_text = response.content.strip() if response.content else ""
 
         if not interpretation_text:
-            raise RuntimeError("interpret_node: LLMが空の解釈を返しました。")
+            # RuntimeErrorを発生させる代わりに、ToolMessageでエラーを返す
+            error_message = "interpret_node: LLMが空の解釈を返しました。"
+            logging.warning(error_message) # Warningレベルに変更
+            return {"messages": [ToolMessage(content=error_message, tool_call_id=tool_call_id)]}
 
     except Exception as e:
         error_message = f"データの解釈中にエラーが発生しました: {e}"
         logging.error(error_message)
         return {"messages": [ToolMessage(content=error_message, tool_call_id=tool_call_id)]}
 
-    # --- 3. 出口: 結果をToolMessageで報告する ---
     return {
         "messages": [
             ToolMessage(
@@ -404,17 +452,14 @@ def interpret_node(state: AgentState):
         ]
     }
 
+
 # python用のCallback
 class CodeCollectorCallback(BaseCallbackHandler):
     def __init__(self):
         self.codes = []
-    
-    # ★★★ on_agent_action から on_tool_start に変更 ★★★
+
     def on_tool_start(self, serialized: dict, input_str: str, **kwargs: Any) -> Any:
-        """ツールが実行を開始する直前に呼び出される"""
-        # 実行されるツールの名前が "python_ast_repl" かどうかをチェック
         if serialized.get("name") == "python_ast_repl":
-            # ツールの入力（Pythonコード）をリストに追加
             self.codes.append(input_str)
 
 def processing_node(state: AgentState):
@@ -422,18 +467,40 @@ def processing_node(state: AgentState):
     自然言語のタスク記述とstate内のデータを受け取り、文脈を理解した上でデータの加工やグラフの作成を行います。
     分析のためにデータの加工やグラフ作成をする必要がある際に使用します。
     """
-    # messagesの最後にあるのが、スーパーバイザーからのツールコール指示 or 専門家へのディスパッチ指示
-    # その指示内容(content)を現在のタスクとして扱う
-    task_description = state["messages"][-1].content
-    # どの指示に対する応答なのかを紐付けるために、tool_call_idを取得しておく
-    tool_call_id = state["messages"][-2].tool_calls[0]['id']
-    
-    logging.info(f"processing_node: df_historyの読み込み開始・・・ '{task_description}'")
-    df_history = state.get("df_history", None)
-    if df_history is None:
-        raise RuntimeError("processing_node: df_historyが空です。利用可能なデータがありません。")
+    try:
+        # --- 修正: スーパーバイザーからの指示の受け取り方 ---
+        supervisor_ai_message = state["messages"][-1]
+        if not isinstance(supervisor_ai_message, AIMessage) or not supervisor_ai_message.tool_calls:
+            error_message = "不正な呼び出し形式です。スーパーバイザーからのAIMessage(tool_calls付き)が見つかりません。"
+            logging.error(f"processing_node: {error_message}")
+            return {"messages": [ToolMessage(content=error_message, tool_call_id=None)]}
 
-    # 会話履歴の直近N件だけ取り出し
+        first_tool_call = supervisor_ai_message.tool_calls[0]
+        tool_call_id = first_tool_call['id']
+
+        arguments_json = first_tool_call['function']['arguments']
+        arguments = json.loads(arguments_json)
+
+        task_description = arguments.get('task_description')
+        if task_description is None:
+            error_message = "task_descriptionがスーパーバイザーの指示に含まれていません。"
+            logging.error(f"processing_node: {error_message}")
+            return {"messages": [ToolMessage(content=error_message, tool_call_id=tool_call_id)]}
+        # --- 修正ここまで ---
+
+    except (IndexError, KeyError, json.JSONDecodeError, AttributeError, ValueError) as e:
+        error_message_detail = f"ノード初期化エラー: {e}. Messages: {state.get('messages')}"
+        logging.error(f"processing_node: {error_message_detail}")
+        current_tool_call_id = locals().get("tool_call_id", None)
+        return {"messages": [ToolMessage(content=error_message_detail, tool_call_id=current_tool_call_id)]}
+
+    logging.info(f"processing_node: df_historyの読み込み開始・・・ '{task_description}'")
+    df_history = state.get("df_history", []) # getのデフォルトを空リストに
+    if not df_history: # df_historyがNoneまたは空の場合
+        error_message = "processing_node: df_historyが空です。利用可能なデータがありません。"
+        logging.warning(error_message)
+        return {"messages": [ToolMessage(content=error_message, tool_call_id=tool_call_id)]}
+
     recent_items = df_history[-history_back_number:]
     df_explain_list = []
     df_locals = {}
@@ -441,12 +508,12 @@ def processing_node(state: AgentState):
         for question, data in entry.items():
             try:
                 df = pd.DataFrame(data)
-                df_name = f"df{idx}"  # 例: df0, df1, ...
+                df_name = f"df{idx}"
                 if not df.empty:
-                    df_locals[df_name] = df  # python_tool用
+                    df_locals[df_name] = df
                     explain = f"""
                     # {df_name}
-                    ## 内容:【{question}】に関するデータ    
+                    ## 内容:【{question}】に関するデータ
                     ## dfの列情報: {list(df.columns)}
                     ## dfの最初の5行:\n{df.head().to_string(index=False)}
                     """
@@ -457,26 +524,24 @@ def processing_node(state: AgentState):
                 logging.error(f"processing_node: df_historyをDataFrameに変換中にエラーが発生しました: {e}")
                 df_explain_list.append(f"■「{question}」に関するデータ:\n(データ形式エラーのため表示できません)\n\n")
 
-    # 有効なDataFrameが1つもなければ終了
     if not df_locals:
-        raise RuntimeError("processing_node: 利用可能なデータが0でした。")
-    
-    full_explain_string = "\n".join(df_explain_list)
+        error_message = "processing_node: 利用可能なDataFrameが0でした。"
+        logging.warning(error_message)
+        return {"messages": [ToolMessage(content=error_message, tool_call_id=tool_call_id)]}
 
-    #pythonツールの定義
-    locals = {**df_locals, "px": px, "pd": pd}
+    full_explain_string = "\n".join(df_explain_list)
+    locals_for_tool = {**df_locals, "px": px, "pd": pd} # `locals`は組み込み関数なので変数名を変更
     python_tool = PythonAstREPLTool(
         name="python_ast_repl",
-        locals=locals, 
+        locals=locals_for_tool,
         description=(
             f"""Pythonコードを実行してデータの加工とグラフ化ができます。対象のDataFrameとして、{",".join(df_locals.keys())}が使用可能です。
             グラフを作成するときにはplotly.express (px) を使用してインタラクティブなグラフを生成し、最終的なグラフオブジェクトは必ず `fig` という変数に格納してください。
             データフレームを成果物とする場合は、データフレームは `final_df` という変数に格納してください。"""
         )
     )
-    tools = [python_tool]
+    tools_for_agent = [python_tool] # `tools`も上書きしないように変数名を変更
 
-    #system_prompt
     system_prompt = """
     あなたはデータ分析のエキスパートです。ユーザーの指示に従い、ツールを使って分析し、結果を返してください。
 
@@ -487,13 +552,8 @@ def processing_node(state: AgentState):
     思考の過程:
     {agent_scratchpad}
     """
-
-    # user_prompt準備
-    # 直近の会話履歴
     conversation_history = state.get("messages", [])
-    # システムメッセージ以外を抽出
     non_system_history = [msg for msg in conversation_history if msg.type != "system"]
-    # 直近N件だけ取り出し
     recent_history = non_system_history[-history_back_number:]
     context = "\n".join([f"{msg.type}: {msg.content}" for msg in recent_history])
 
@@ -503,7 +563,7 @@ def processing_node(state: AgentState):
 
     【現在のタスク】
     {task_description}
-    
+
     【ユーザーの全体的な質問の文脈】
     {context}
 
@@ -519,10 +579,7 @@ def processing_node(state: AgentState):
     実行例:
     import pandas as pd
     final_df = df.groupby('date')['sales'].sum().reset_index()
-
     """
-
-    #promptをまとめてAgentを準備
     prompt = ChatPromptTemplate.from_messages([
         ("system", system_prompt),
         ("user", "{input}"),
@@ -530,51 +587,59 @@ def processing_node(state: AgentState):
     ])
 
     logging.info(f"processing_node: 分析開始・・・ '{task_description}'")
-    llm_with_tool = llm.bind_tools(tools)
-    agent = create_openai_tools_agent(llm_with_tool, tools, prompt)
+    llm_with_tool = llm.bind_tools(tools_for_agent) # 修正: tools_for_agentを使用
+    agent = create_openai_tools_agent(llm_with_tool, tools_for_agent, prompt) # 修正: tools_for_agentを使用
     agent_executor = AgentExecutor(
-        agent=agent, 
-        tools=[python_tool],
+        agent=agent,
+        tools=tools_for_agent, # 修正: tools_for_agentを使用
         verbose=True,
-        handle_parsing_errors=True # 解析エラー時の処理を追加するとより堅牢
+        handle_parsing_errors=True
     )
 
-    #agentの実行開始
     code_collector = CodeCollectorCallback()
     logging.info(f"processing_node: 生成AIが考えています・・・ '{task_description}'")
     agent_response = agent_executor.invoke(
-        {"input":user_prompt},
-        {"callbacks": [code_collector]} 
-        )
+        {"input": user_prompt},
+        {"callbacks": [code_collector]}
+    )
     logging.info(f"processing_node: Agent response: {agent_response}")
-    logging.info(f"processing_node: Agent response: {code_collector.codes}")
+    logging.info(f"processing_node: Agent codes: {code_collector.codes}") # "Agent response"から"Agent codes"に修正
+
+    fig_json = None
+    result_df_json = None
+    new_history_item = None # 初期化
 
     try:
         logging.info(f"processing_node: コード検証中・・・ '{task_description}'")
-        # 実行環境のスコープはPythonAstREPLを使いまわす
-        execution_scope = locals
-        for i in code_collector.codes:
-            code_dict = ast.literal_eval(i)
-            code_str = code_dict["query"]   
-            exec(code_str, execution_scope)
-        
-        # 最終的なオブジェクトをスコープから取得して利用
+        execution_scope = locals_for_tool.copy() # PythonAstREPLToolのlocalsをコピーして使用
+        for code_block_str in code_collector.codes:
+            # LangChainのPythonAstREPLToolは、入力が直接コード文字列であることを期待している場合がある
+            # もしcode_block_strが {'query': '...'} のような形式ならパースが必要
+            code_to_execute = code_block_str
+            if isinstance(code_block_str, str):
+                try:
+                    # 文字列が辞書形式（例: "{'query': 'print(1)'}"）であるか試す
+                    code_dict = ast.literal_eval(code_block_str)
+                    if isinstance(code_dict, dict) and "query" in code_dict:
+                        code_to_execute = code_dict["query"]
+                except (SyntaxError, ValueError):
+                    # ast.literal_evalが失敗した場合は、そのままコード文字列として扱う
+                    pass
+            
+            exec(code_to_execute, execution_scope)
+
         fig = execution_scope.get('fig')
         result_df = execution_scope.get('final_df')
-    
+
         if fig is not None:
             fig_json = fig.to_json()
-        else:
-            fig_json = None
-
         if result_df is not None:
             result_df_json = result_df.to_json(orient="records", force_ascii=False)
-            new_history_item = {task_description: result_df.to_dict(orient="records")}
-        else:
-            result_df_json = None
-            new_history_item = None
+            if not result_df.empty: # 空のDataFrameは履歴に追加しないようにする
+                new_history_item = {task_description: result_df.to_dict(orient="records")}
 
-        if (fig_json is None) and (result_df_json is None):
+
+        if fig_json is None and result_df_json is None:
             content = "データも、グラフも生成されませんでした"
         else:
             content = json.dumps({
@@ -583,12 +648,14 @@ def processing_node(state: AgentState):
             }, ensure_ascii=False)
 
     except Exception as e:
-        error_message = f"生成AIがデータ加工・グラフ作成に失敗しました。: {e}"
-        logging.info(f"processing_node: {error_message}")
-        # エラーが発生した場合も、ToolMessageで結果を返す
+        error_message = f"生成AIがデータ加工・グラフ作成に失敗しました。: {e}. 実行しようとしたコード: {code_collector.codes}"
+        logging.error(f"processing_node: {error_message}")
         return {"messages": [ToolMessage(content=error_message, tool_call_id=tool_call_id)]}
 
-    # stateを直接いじるのではなく、結果をメッセージとして返す
+    updated_df_history = state.get("df_history", [])
+    if new_history_item: # new_history_itemがNoneでない（つまり有効なDataFrameが生成された）場合のみ追加
+        updated_df_history = updated_df_history + [new_history_item]
+    
     return {
         "messages": [
             ToolMessage(
@@ -596,141 +663,141 @@ def processing_node(state: AgentState):
                 tool_call_id=tool_call_id
             )
         ],
-        "df_history": state.get("df_history", []) + [new_history_item],
+        "df_history": updated_df_history,
     }
 
 # --- 2. スーパーバイザーの出力スキーマ定義 (Pydantic) ---
-# --- 2. スーパーバイザーのディスパッチ指示用スキーマ ---
-# LLMにこの形式で出力するように強制する
 class DispatchDecision(BaseModel):
     """専門家エージェントにタスクを割り振る際の意思決定スキーマ"""
     next_agent: str = Field(description="次に指名すべき専門家（ノード）の名前。利用可能な専門家がいない場合は 'FINISH'。")
     task_description: str = Field(description="指名した専門家に与える、具体的で明確な指示内容。")
     rationale: str = Field(description="なぜその判断を下したのかの簡潔な理由。")
-                           
-# スーパーバイザーのLLMチェーン定義 ---
-# 利用可能な専門家（ノード）のリスト
-members = ["sql_node", "processing_node", "interpret_node"]
-tools = [metadata_retrieval_node, analysis_plan_node]
 
-# スーパーバイザーに与えるシステムプロンプト
+members = ["sql_node", "processing_node", "interpret_node"] # interpret_node を専門家リストに追加
+supervisor_tools = [metadata_retrieval_node, analysis_plan_node] # supervisorが直接使うツール名変更
+
 system_prompt_supervisor = (
     "あなたはAIチームを率いる熟練のプロジェクトマネージャーです。\n"
     "あなたの仕事は、ユーザーの要求に基づき、以下のいずれかのアクションを選択することです。\n"
     "1. 自分でツールを実行する: 簡単な情報照会などは、あなたが直接ツールを実行して回答してください。\n"
     "2. 専門家に仕事を割り振る: 複雑な作業は、タスクを分解し、以下の専門家メンバーに具体的で明確な指示を出してください。\n\n"
     "== 利用可能なツール ==\n"
-    "- metadata_retrieval_tool: データベースのテーブル定義やカラムについて答える。\n\n"
+    "- metadata_retrieval_node: データベースのテーブル定義やカラムについて答える。\n" #ツール名を修正
     "- analysis_plan_node: 分析のプランを立てる\n\n"
 
     "== 専門家メンバーリスト ==\n"
-    "- sql_node: 依頼に従ってSQLを生成し、データを取得する\n\n"
-    "- processing_node: 依頼に従ってデータの加工やグラフ作成をする\n\n"
-    "- interpret_node: 依頼に従ってデータの解釈を行う\n\n"
+    "- sql_node: 依頼に従ってSQLを生成し、データを取得する\n"
+    "- processing_node: 依頼に従ってデータの加工やグラフ作成をする\n"
+    "- interpret_node: 依頼に従ってデータの解釈を行う\n\n" # interpret_node を専門家リストに追加
     "== 判断ルール ==\n"
     "まずツールで解決できるか検討し、できなければ専門家への割り振りを考えてください。\n"
     "専門家へ割り振る際は、次に指名すべきメンバーと、そのメンバーへの具体的な指示内容を決定してください。\n"
     "全てのタスクが完了したと判断した場合は、next_agentに 'FINISH' を指定してください。"
 )
 
-# プロンプトテンプレートの作成
 supervisor_prompt = ChatPromptTemplate.from_messages([
     ("system", system_prompt_supervisor),
     MessagesPlaceholder(variable_name="messages"),
 ])
-# LLMに「ディスパッチ指示」という名の「ツール」と、実際のツール群の両方を教える
-# これにより、LLMはディスパッチするか、ツールを使うかを選べるようになる
-llm_with_tools = llm.bind_tools(tools + [DispatchDecision])
+llm_with_supervisor_tools = llm.bind_tools(supervisor_tools + [DispatchDecision]) # 修正: supervisor_tools を使用
+supervisor_chain = supervisor_prompt | llm_with_supervisor_tools # 修正: llm_with_supervisor_tools を使用
 
-# LLMと出力スキーマを結合して、構造化出力を強制するチェーンを作成
-# これがスーパーバイザーの頭脳となる
-supervisor_chain = supervisor_prompt | llm_with_tools
-
-# --- 4. スーパーバイザーノード本体 ---
 def supervisor_node(state: AgentState):
     """スーパーバイザーとして次にどのアクションをとるべきか判断する"""
     logging.info("--- スーパーバイザー ノード実行 ---")
-    
-    response = supervisor_chain.invoke({"messages": state["messages"]})
-    logging.info(response)
+    logging.info(f"Supervisor messages: {state['messages']}") # 入力メッセージをログに出力
 
-    tool_calls = response.additional_kwargs.get("tool_calls", [])
-    # 2. tool_callsがあるかどうかで分岐
+    response = supervisor_chain.invoke({"messages": state["messages"]})
+    logging.info(f"Supervisor response: {response}") # LLMからのレスポンスをログに出力
+
+    # AIMessageの場合、tool_callsは additional_kwargsではなく .tool_calls でアクセス (LangChainのバージョンによる)
+    # responseがAIMessageインスタンスであることを確認
+    if isinstance(response, AIMessage):
+        tool_calls = response.tool_calls or [] # response.tool_calls が None の場合も考慮
+    else:
+        # 互換性のため、古い形式も試みる (通常はAIMessageを期待)
+        tool_calls = response.additional_kwargs.get("tool_calls", [])
+
     if not tool_calls:
-        logging.info("supervisor_node: 判断:応答完了")
-        return{
-            "messages":[*state["messages"], response],
-            "next":"FINISH"
-            }
+        logging.info("supervisor_node: 判断: (tool_callsなし)応答完了または直接応答")
+        # LLMが直接応答した場合 (ツールコールもディスパッチもなし)
+        return {
+            "messages": [*state["messages"], response], # LLMの応答を履歴に追加
+            "next": "FINISH" # FINISHするか、ユーザーに応答を返す特別なノードを設けるか
+        }
     else:
         first_call = tool_calls[0]
+        # tool_callsの構造を確認: 'function'キーがあり、その下に'arguments'があるか
+        if "function" not in first_call or "arguments" not in first_call["function"]:
+            logging.error(f"supervisor_node: 不正なtool_call構造: {first_call}")
+            # エラー処理: FINISHするか、エラーメッセージを返すか
+            error_response = AIMessage(content="Tool call structure is invalid.")
+            return {"messages": [*state["messages"], error_response], "next": "FINISH"}
+
         args_json = first_call["function"]["arguments"]
         try:
             args = json.loads(args_json)
-        except Exception as e:
-            raise (f"argumentsのJSONデコードに失敗:{e}")
+        except json.JSONDecodeError as e:
+            logging.error(f"supervisor_node: argumentsのJSONデコードに失敗: {e}, args_json: {args_json}")
+            # エラー処理
+            error_response = AIMessage(content=f"Failed to decode tool call arguments: {e}")
+            return {"messages": [*state["messages"], error_response], "next": "FINISH"}
 
-        if "next_agent" not in args:            
-            logging.info("判断: ツールを直接実行します。")
-            # 新しいメッセージとしてツールコールを追加し、'next'を'tools'に設定
+        # DispatchDecisionのスキーマに 'next_agent' が含まれているかで判断
+        if "next_agent" not in args:
+            logging.info("supervisor_node: 判断: ツールを直接実行します。")
+            # スーパーバイザーがツールを実行するケース
+            # この場合、response (AIMessage) にはツール実行に必要な情報(tool_call)が含まれている
             return {"messages": [*state["messages"], response], "next": "tools"}
-            
-        # CASE 2: LLMが専門家に割り振ると判断した場合
-        # response.tool_calls[0]['args']にDispatchDecisionの引数が入ってくる
         else:
-            # Pydanticモデルにパースして扱いやすくする
-            dispatch_decision = DispatchDecision(**response.tool_calls[0]['args'])
-            logging.info(f"判断: 専門家 '{dispatch_decision.next_agent}' にタスクを割り振ります。")
-            logging.info(f"判断理由: {dispatch_decision.rationale}")
-            logging.info(f"具体的な指示: {dispatch_decision.task_description}")
-            
-            # 次のノード（専門家）に渡すためのメッセージを作成
-            # これにより、専門家は「スーパーバイザーからこの指示が来た」と認識できる
-            dispatch_message = ToolMessage(
-                content=f"以下の指示を実行してください：\n\n{dispatch_decision.task_description}",
-                tool_call_id=response.tool_calls[0]['id'] # どの判断に対応するかを紐付け
-            )
+            # 専門家へのディスパッチ
+            try:
+                dispatch_decision = DispatchDecision(**args)
+            except Exception as e: # Pydanticのバリデーションエラーなど
+                logging.error(f"supervisor_node: DispatchDecisionのパースに失敗: {e}, args: {args}")
+                error_response = AIMessage(content=f"Failed to parse dispatch decision: {e}")
+                return {"messages": [*state["messages"], error_response], "next": "FINISH"}
+
+            logging.info(f"supervisor_node: 判断: 専門家 '{dispatch_decision.next_agent}' にタスクを割り振ります。")
+            logging.info(f"supervisor_node: 判断理由: {dispatch_decision.rationale}")
+            logging.info(f"supervisor_node: 具体的な指示: {dispatch_decision.task_description}")
+
+            # --- 修正: dispatch_messageの作成と追加を削除 ---
+            # AIMessage (response) をそのまま履歴に追加し、
+            # 専門家ノードがこのAIMessageのtool_callsから指示を読み取る
             return {
-                "messages": [*state["messages"], response, dispatch_message], # 必要に応じてHumanMessage/AIMessage
+                "messages": [*state["messages"], response], # response（AIMessage）を履歴に追加
                 "next": dispatch_decision.next_agent
             }
-
 
 def build_workflow():
     graph_builder = StateGraph(AgentState)
 
-    # 1. スーパーバイザーノードを追加
     graph_builder.add_node("supervisor", supervisor_node)
-
-    # 2. ツール実行ノードを追加
-    # ToolNodeは、スーパーバイザーが呼び出しを決めたツールを自動で実行してくれる便利なノード
-    # スーパーバイザーと各専門家をノードとして追加
-    graph_builder.add_node("sql_node", sql_node) 
+    graph_builder.add_node("sql_node", sql_node)
     graph_builder.add_node("processing_node", processing_node)
-    graph_builder.add_node("interpret_node", interpret_node)
-    tool_node = ToolNode(tools)
+    graph_builder.add_node("interpret_node", interpret_node) # interpret_node を追加
+    tool_node = ToolNode(supervisor_tools) # 修正: supervisor_tools を使用
     graph_builder.add_node("tools", tool_node)
 
-    # エントリーポイントはスーパーバイザー
     graph_builder.set_entry_point("supervisor")
 
-    # スーパーバイザーの決定 (`state['next']`) に基づいて、次に進むノードを決める
     graph_builder.add_conditional_edges(
         "supervisor",
         lambda state: state["next"],
         {
             "sql_node": "sql_node",
             "processing_node": "processing_node",
-            "tools":"tools",
+            "interpret_node": "interpret_node", # interpret_node へのエッジを追加
+            "tools": "tools",
             "FINISH": END
         }
     )
 
-
-    # 各専門家の作業が終わったら、必ずスーパーバイザーに報告に戻る
     graph_builder.add_edge("sql_node", "supervisor")
     graph_builder.add_edge("processing_node", "supervisor")
+    graph_builder.add_edge("interpret_node", "supervisor") # interpret_node から supervisor へのエッジを追加
     graph_builder.add_edge("tools", "supervisor")
-    
+
     memory = MemorySaver()
     return graph_builder.compile(checkpointer=memory)


### PR DESCRIPTION
コードを実行すると以下のエラーが出ます。
openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid parameter: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'.", ...}}
このエラーは、OpenAIのAPIに渡されたメッセージの履歴（messages）の構造が、APIのルールに違反しているために発生しています。

エラーの根本原因

エラーメッセージの核心は 「roleがtoolのメッセージは、その直前にtool_callsを持つメッセージがなければならない」 というルールです。

現在のコードの実行フローでは、このルールに違反するメッセージ履歴が構築されてしまっています。具体的には、以下の流れで問題が発生します。

スーパーバイザーが専門家を指名:

supervisor_nodeは、sql_nodeにタスクを割り振るという決定を下します。

このとき、AIMessage（tool_callsを含む）と、sql_nodeへの指示を記述したToolMessage（dispatch_message）の2つをメッセージ履歴に追加します。

この時点での履歴の末尾: [..., AIMessage(tool_callsあり), ToolMessage(指示)]。ここまでは正常です。

専門家がタスクを実行:

sql_nodeが実行され、SQLの結果をToolMessageとして新たに追加します。

不正なメッセージ履歴が完成:

sql_nodeの処理が終わると、メッセージ履歴の末尾は以下のようになります。 [..., AIMessage(tool_callsあり), ToolMessage(指示), ToolMessage(SQLの結果)]

この履歴で再度スーパーバイザーがLLMを呼び出そうとすると、2番目のToolMessage（SQLの結果）の直前にあるのはToolMessage（指示）です。tool_callsを持つAIMessageではありません。

これによりOpenAI APIのルールに違反し、400 Bad Requestエラーが発生します。

解決策

スーパーバイザーが専門家（sql_nodeなど）を呼び出す際のメッセージの渡し方を修正する必要があります。具体的には、指示のためだけの中間的なToolMessage（dispatch_message）を作成するのをやめ、専門家ノードがスーパーバイザーからのAIMessageを直接読んでタスク内容を理解するように変更します。

これにより、メッセージ履歴が [..., AIMessage(tool_callsあり), ToolMessage(結果)] という正常な形式に保たれます。

修正後のコード

supervisor_node と、それによって呼び出される専門家ノード（sql_node,interpret_nodeとprocessing_node）を以下のように修正してください。



【supervisor_node の修正】

dispatch_messageを作成・追加している部分を削除します。



【専門家ノードの修正】

指示の受け取り方を変更